### PR TITLE
Fix MiniCam frame rate

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/ExamplesWorkflows/UclaMiniCam.bonsai
+++ b/ExamplesWorkflows/UclaMiniCam.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.5"
+<WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:p1="clr-namespace:OpenEphys.Miniscope;assembly=OpenEphys.Miniscope"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -13,7 +13,7 @@
           <p1:Index>0</p1:Index>
           <p1:LedBrightness>0</p1:LedBrightness>
           <p1:SensorGain>Low</p1:SensorGain>
-          <p1:FramesPerSecond>Fps50</p1:FramesPerSecond>
+          <p1:FramesPerSecond>30</p1:FramesPerSecond>
         </Combinator>
       </Expression>
       <Expression xsi:type="MemberSelector">

--- a/ExamplesWorkflows/UclaMiniCamTriggered.bonsai
+++ b/ExamplesWorkflows/UclaMiniCamTriggered.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.5"
+<WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:p1="clr-namespace:OpenEphys.Miniscope;assembly=OpenEphys.Miniscope"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -13,7 +13,7 @@
           <p1:Index>0</p1:Index>
           <p1:LedBrightness>0</p1:LedBrightness>
           <p1:SensorGain>Low</p1:SensorGain>
-          <p1:FramesPerSecond>Fps50</p1:FramesPerSecond>
+          <p1:FramesPerSecond>30</p1:FramesPerSecond>
         </Combinator>
       </Expression>
       <Expression xsi:type="rx:Condition">


### PR DESCRIPTION
- The frame rate settings, copied for the Qt software, were completely non functional
- Fixes #21 